### PR TITLE
[embedded-graphics] Paint Example

### DIFF
--- a/examples/paint-mode/Cargo.toml
+++ b/examples/paint-mode/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Glenn Hope <glenn.alexander.hope@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-psp = { version = "0.1", features = [ "embedded-graphics" ] }
+psp = { path = "../../psp", features = ["embedded-graphics"] }
 embedded-graphics = "0.6.2"
 numtoa = "0.2"

--- a/examples/paint-mode/Cargo.toml
+++ b/examples/paint-mode/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "psp-paint-mode"
+version = "0.1.0"
+authors = ["Glenn Hope <glenn.alexander.hope@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+psp = { version = "0.1", features = [ "embedded-graphics" ] }
+embedded-graphics = "0.6.2"
+numtoa = "0.2"
+arrayvec = { version = "0.5", default-features = false }

--- a/examples/paint-mode/Cargo.toml
+++ b/examples/paint-mode/Cargo.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 authors = ["Glenn Hope <glenn.alexander.hope@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 psp = { version = "0.1", features = [ "embedded-graphics" ] }
 embedded-graphics = "0.6.2"
 numtoa = "0.2"
-arrayvec = { version = "0.5", default-features = false }

--- a/examples/paint-mode/Psp.toml
+++ b/examples/paint-mode/Psp.toml
@@ -1,0 +1,1 @@
+title = "Paint Mode"

--- a/examples/paint-mode/src/analog_stick_to_delta.rs
+++ b/examples/paint-mode/src/analog_stick_to_delta.rs
@@ -1,0 +1,124 @@
+// Number of "pixels" (out of 127 in each direction)
+// to ignore in the center of the analog stick, because
+// it's very common to have the stick rest slighly off-center.
+const DEADZONE: i32 = 10;
+
+// The maximum number of pixels to move in a single tick,
+// essentially the "mouse sensitivity" of the analog stick.
+const MAX_SPEED: i32 = 4;
+
+// Carve a number of rings around our deadzone equal to MAX_SPEED.
+const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
+
+
+// Convert the analog stick position to a number of pixels to move
+// in the direction it is being held.
+//
+// First, we need to treat 127, 127 as 0,0 on a Cartesian plane.
+// We receive coordinates from the PSP control stick like this:
+// 
+// +--------------------+
+// |0,0            255,0|
+// |                    |
+// |                    |
+// |                    |
+// |      127,127       |
+// |                    |
+// |                    |
+// |                    |
+// |0,255        255,255| 
+// +--------------------+
+//
+// So we subtract 127 to make our values look like this:
+//
+// +--------------------+
+// |-127,-127   127,-127|
+// |                    |
+// |                    |
+// |                    |
+// |         0,0        |
+// |                    |
+// |                    |
+// |                    |
+// |-127,127     127,127| 
+// +--------------------+
+//
+// Then, we carve out a "deadzone" around 0,0 where inputs are equal to zero.
+// So, for a DEADZONE of 8, we would have:
+//
+// +--------------------+
+// |                    |
+// |                    |
+// |    -8,-8   8,-8    |
+// |      +------+      |
+// |      |      |      |
+// |      |      |      |
+// |      +------+      |
+// |    -8,8    8,8     |
+// |                    |
+// |                    |
+// +--------------------+
+//
+// Now, we use MAX_SPEED as the number of "rings" around 0,0.
+// So for a MAX_SPEED value of 3, this would look like:
+//
+//          For Y:            -    For X:    +   
+//  +--------------------+ +--------------------+
+//  |33333333333333333333| |33221100000000112233|
+// -|22222222222222222222| |33221100000000112233|
+//  |11111111111111111111| |33221100000000112233|
+//  |000000+------+000000| |332211+------+112233|
+//  |000000|      |000000| |332211|      |112233|
+//  |000000|      |000000| |332211|      |112233|
+//  |000000+------+000000| |332211+------+112233|
+//  |11111111111111111111| |33221100000000112233|
+// +|22222222222222222222| |33221100000000112233|
+//  |33333333333333333333| |33221100000000112233|
+//  +--------------------+ +--------------------+
+//
+// And for a MAX_SPEED of 6, something like this:
+// 
+//          For Y:            -    For X:    +   
+//  +--------------------+ +--------------------+
+//  |66666666666666666666| |65432100000000123456|
+// -|44444444444444444444| |65432100000000123456|
+//  |22222222222222222222| |65432100000000123456|
+//  |000000+------+000000| |654321+------+123456|
+//  |000000|      |000000| |654321|      |123456|
+//  |000000|      |000000| |654321|      |123456|
+//  |000000+------+000000| |654321+------+123456|
+//  |22222222222222222222| |65432100000000123456|
+// +|44444444444444444444| |65432100000000123456|
+//  |66666666666666666666| |65432100000000123456|
+//  +--------------------+ +--------------------+
+//
+// Or, visualized differently for a MAX_SPEED of 8:
+//
+// +--------------------+
+// |                    |
+// |                    |
+// |        0,-1        |
+// |      +------+      |
+// |      | 0,0  |1,0   |
+// |      |      |      |
+// |      +------+      |
+// |                    |
+// |  -4,4              |
+// |                 8,8|
+// +--------------------+
+//
+pub fn convert_analog_to_delta_with_sensitivity_deadzone(raw_val: u8) -> i32 {
+    let delta_val = (raw_val as i32) - 127;
+
+    // Zero out a "deadzone" around 0,0 to adjust for joysticks that sit off-center.
+    let distance_without_deadzone = if delta_val > -DEADZONE && delta_val < DEADZONE {
+        0
+    } else if delta_val < -DEADZONE {
+        delta_val + DEADZONE
+    } else {
+        delta_val - DEADZONE
+    };
+
+
+    distance_without_deadzone / SPEED_MODIFIER
+}

--- a/examples/paint-mode/src/analog_stick_to_delta.rs
+++ b/examples/paint-mode/src/analog_stick_to_delta.rs
@@ -10,13 +10,12 @@ const MAX_SPEED: i32 = 4;
 // Carve a number of rings around our deadzone equal to MAX_SPEED.
 const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
 
-
 // Convert the analog stick position to a number of pixels to move
 // in the direction it is being held.
 //
 // First, we need to treat 127, 127 as 0,0 on a Cartesian plane.
 // We receive coordinates from the PSP control stick like this:
-// 
+//
 // +--------------------+
 // |0,0            255,0|
 // |                    |
@@ -26,7 +25,7 @@ const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
 // |                    |
 // |                    |
 // |                    |
-// |0,255        255,255| 
+// |0,255        255,255|
 // +--------------------+
 //
 // So we subtract 127 to make our values look like this:
@@ -40,7 +39,7 @@ const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
 // |                    |
 // |                    |
 // |                    |
-// |-127,127     127,127| 
+// |-127,127     127,127|
 // +--------------------+
 //
 // Then, we carve out a "deadzone" around 0,0 where inputs are equal to zero.
@@ -62,7 +61,7 @@ const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
 // Now, we use MAX_SPEED as the number of "rings" around 0,0.
 // So for a MAX_SPEED value of 3, this would look like:
 //
-//          For Y:            -    For X:    +   
+//          For Y:            -    For X:    +
 //  +--------------------+ +--------------------+
 //  |33333333333333333333| |33221100000000112233|
 // -|22222222222222222222| |33221100000000112233|
@@ -77,8 +76,8 @@ const SPEED_MODIFIER: i32 = 127 / MAX_SPEED;
 //  +--------------------+ +--------------------+
 //
 // And for a MAX_SPEED of 6, something like this:
-// 
-//          For Y:            -    For X:    +   
+//
+//          For Y:            -    For X:    +
 //  +--------------------+ +--------------------+
 //  |66666666666666666666| |65432100000000123456|
 // -|44444444444444444444| |65432100000000123456|
@@ -118,7 +117,6 @@ pub fn convert_analog_to_delta_with_sensitivity_deadzone(raw_val: u8) -> i32 {
     } else {
         delta_val - DEADZONE
     };
-
 
     distance_without_deadzone / SPEED_MODIFIER
 }

--- a/examples/paint-mode/src/background.rs
+++ b/examples/paint-mode/src/background.rs
@@ -1,0 +1,19 @@
+use embedded_graphics::{
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::rectangle::Rectangle,
+    style::{PrimitiveStyle, PrimitiveStyleBuilder, Styled},
+};
+
+use psp::{SCREEN_HEIGHT, SCREEN_WIDTH};
+
+pub fn get_background() -> Styled<Rectangle, PrimitiveStyle<Rgb888>> {
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb888::BLACK)
+        .build();
+    Rectangle::new(
+        Point::new(0, 0),
+        Point::new(SCREEN_WIDTH as i32, SCREEN_HEIGHT as i32),
+    )
+    .into_styled(style)
+}

--- a/examples/paint-mode/src/debug_textbox.rs
+++ b/examples/paint-mode/src/debug_textbox.rs
@@ -1,0 +1,55 @@
+use core::str;
+use numtoa::NumToA;
+
+use embedded_graphics::{
+    fonts::{Font6x8, Text},
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::rectangle::Rectangle,
+    style::{PrimitiveStyle, PrimitiveStyleBuilder, Styled, TextStyle},
+};
+
+use psp::embedded_graphics::Framebuffer;
+use psp::sys::SceCtrlData;
+use psp::{SCREEN_HEIGHT, SCREEN_WIDTH};
+pub fn get_textbox<'a>() -> Styled<Text<'a>, TextStyle<Rgb888, Font6x8>> {
+    Text::new("", get_textbox_top_left()).into_styled(TextStyle::new(Font6x8, Rgb888::WHITE))
+}
+
+fn get_textbox_top_left() -> Point {
+    Point::new(SCREEN_WIDTH as i32 - 42, SCREEN_HEIGHT as i32 - 8)
+}
+
+fn get_textbox_wipe_rect() -> Styled<Rectangle, PrimitiveStyle<Rgb888>> {
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(Rgb888::BLACK)
+        .build();
+    Rectangle::new(
+        get_textbox_top_left(),
+        Point::new(SCREEN_WIDTH as i32, SCREEN_HEIGHT as i32),
+    )
+    .into_styled(style)
+}
+
+pub fn draw_debug_textbox(disp: &mut Framebuffer, pad_data: &SceCtrlData) {
+    // Create a str holding our analog pad X and Y values
+    let mut holder = [' ' as u8; 7];
+    holder[3] = ':' as u8;
+    pad_data.lx.numtoa(10, &mut holder[..3]);
+    pad_data.ly.numtoa(10, &mut holder[4..]);
+
+    let pad_debug_data_str = unsafe {
+        // We can be extremely sure that our array holds nothing
+        // but ASCII values, so we can safely skip UTF-8 checks.
+        str::from_utf8_unchecked(&holder)
+    };
+
+    // Instantiate our textboxes
+    let textbox_wipe = get_textbox_wipe_rect();
+    let mut textbox = get_textbox();
+    textbox.primitive.text = pad_debug_data_str;
+
+    // Actually clear and redraw the textbox on screen
+    textbox_wipe.draw(disp).unwrap();
+    textbox.draw(disp).unwrap();
+}

--- a/examples/paint-mode/src/drawobject.rs
+++ b/examples/paint-mode/src/drawobject.rs
@@ -1,0 +1,206 @@
+use embedded_graphics::{
+    pixelcolor::Rgb888,
+    prelude::*,
+    primitives::{circle::Circle, rectangle::Rectangle, triangle::Triangle, line::Line},
+    style::{PrimitiveStyle, PrimitiveStyleBuilder, Styled},
+};
+
+use psp::embedded_graphics::Framebuffer;
+
+type StyledRect = Styled<Rectangle, PrimitiveStyle<Rgb888>>;
+type StyledCirc = Styled<Circle, PrimitiveStyle<Rgb888>>;
+type StyledTri = Styled<Triangle, PrimitiveStyle<Rgb888>>;
+type StyledX = [Styled<Line, PrimitiveStyle<Rgb888>>; 2];
+
+pub enum DrawObject {
+    Circ(StyledCirc),
+    Rect(StyledRect),
+    Tri(StyledTri),
+    X(StyledX),
+}
+
+impl DrawObject {
+    pub fn size(&self) -> u32 {
+        match self {
+            Self::Circ(circ) => circ.primitive.radius,
+            Self::Tri(tri) => tri.primitive.size().height / 2,
+            Self::Rect(rect) => rect.primitive.size().height / 2,
+            Self::X(x) => x[0].primitive.size().height / 2,
+        }
+    }
+
+    pub fn draw(&self, disp: &mut Framebuffer) {
+        match self {
+            Self::Circ(circ) => circ.draw(disp).unwrap(),
+            Self::Tri(tri) => tri.draw(disp).unwrap(),
+            Self::Rect(rect) => rect.draw(disp).unwrap(),
+            Self::X(x) => { for line in x { line.draw(disp).unwrap(); } },
+        };
+    }
+
+    pub fn translate_mut(&mut self, point: Point) {
+        match self {
+            Self::Circ(circ) => {circ.translate_mut(point);},
+            Self::Tri(tri) => {tri.translate_mut(point);},
+            Self::Rect(rect) => {rect.translate_mut(point);},
+            Self::X(x) => { for line in x { line.translate_mut(point); } },
+        };
+    }
+
+    pub fn grow(&mut self) {
+        let size = self.size();
+        if size < 31 {
+            match self {
+                Self::Circ(circ) => circ.primitive.radius += 1,
+                Self::Tri(tri) => grow_triangle(tri),
+                Self::Rect(rect) => grow_rectangle(rect),
+                Self::X(x) => grow_x(x),
+            }
+        }
+    }
+
+    pub fn shrink(&mut self) {
+        let size = self.size();
+        if size > 2 {
+            match self {
+                Self::Circ(circ) => circ.primitive.radius -= 1,
+                Self::Tri(tri) => shrink_triangle(tri),
+                Self::Rect(rect) => shrink_rectangle(rect),
+                Self::X(x) => shrink_x(x),
+            }
+        }
+    }
+
+    pub fn center(&self) -> Point {
+        match self {
+            Self::Circ(circ) => circ.primitive.center,
+            Self::Tri(tri) => Point::new(
+                tri.primitive.p1.x,
+                (tri.primitive.p1.y + tri.primitive.p2.y) / 2,
+            ),
+            Self::Rect(rect) => Point::new(
+                (rect.primitive.top_left.x + rect.primitive.bottom_right.x) / 2,
+                (rect.primitive.top_left.y + rect.primitive.bottom_right.y) / 2,
+            ),
+
+            Self::X(x) => Point::new(
+                (x[0].primitive.start.x + x[0].primitive.end.x) / 2,
+                (x[0].primitive.start.y + x[0].primitive.end.y) / 2,
+            ),
+        }
+    }
+
+    pub fn new_circle(point: Point, size: u32) -> Self {
+        Self::Circ(Circle::new(point, size).into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(Rgb888::RED)
+                .stroke_width(1)
+                .build(),
+        ))
+    }
+
+    pub fn new_triangle(point: Point, size: u32) -> Self {
+        let mut tri = Triangle::new(
+            point,
+            point,
+            point,
+        )
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+            .stroke_color(Rgb888::GREEN)
+            .stroke_width(1)
+            .build(),
+        );
+        grow_triangle_by(&mut tri, size as _);
+        Self::Tri(tri)
+    }
+
+    pub fn new_rectangle(point: Point, size: u32) -> Self {
+        let mut rect = Rectangle::new(
+            point,
+            point,
+        )
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+            .stroke_color(Rgb888::MAGENTA)
+            .stroke_width(1)
+            .build(),
+        );
+        grow_rectangle_by(&mut rect, size as _);
+        Self::Rect(rect)
+    }
+
+    pub fn new_x(point: Point, size: u32) -> Self {
+        let line_1 = Line::new(
+            point,
+            point,
+        ).into_styled(
+            PrimitiveStyleBuilder::new()
+            .stroke_color(Rgb888::BLUE)
+            .stroke_width(1)
+            .build(),
+        );
+        let line_2 = line_1.clone();
+        let mut x = [line_1, line_2];
+        grow_x_by(&mut x, size as _);
+        Self::X(x)
+    }
+}
+
+fn grow_triangle(styled_tri: &mut StyledTri) {
+    grow_triangle_by(styled_tri, 1)
+}
+
+fn shrink_triangle(styled_tri: &mut StyledTri) {
+    grow_triangle_by(styled_tri, -1)
+}
+
+fn grow_triangle_by(styled_tri: &mut StyledTri, grow_by: i32) {
+    let mut tri = &mut styled_tri.primitive;
+    tri.p1.y -= grow_by;
+
+    tri.p2.x -= grow_by;
+    tri.p2.y += grow_by;
+
+    tri.p3.x += grow_by;
+    tri.p3.y += grow_by;
+}
+
+fn grow_rectangle(styled_rect: &mut StyledRect) {
+    grow_rectangle_by(styled_rect, 1)
+}
+
+fn shrink_rectangle(styled_rect: &mut StyledRect) {
+    grow_rectangle_by(styled_rect, -1)
+}
+
+fn grow_rectangle_by(styled_rect: &mut StyledRect, grow_by: i32) {
+    let mut rect = &mut styled_rect.primitive;
+    rect.top_left.x -= grow_by;
+    rect.top_left.y -= grow_by;
+
+    rect.bottom_right.x += grow_by;
+    rect.bottom_right.y += grow_by;
+}
+
+fn grow_x(styled_x: &mut StyledX) {
+    grow_x_by(styled_x, 1)
+}
+
+fn shrink_x(styled_x: &mut StyledX) {
+    grow_x_by(styled_x, -1)
+}
+
+fn grow_x_by(styled_x: &mut StyledX, grow_by: i32) {
+    let mut line_1 = &mut styled_x[0].primitive;
+    line_1.start.x -= grow_by;
+    line_1.start.y -= grow_by;
+    line_1.end.x += grow_by;
+    line_1.end.y += grow_by;
+
+    let mut line_2 = &mut styled_x[1].primitive;
+    line_2.start.x -= grow_by;
+    line_2.start.y += grow_by;
+    line_2.end.x += grow_by;
+    line_2.end.y -= grow_by;
+}

--- a/examples/paint-mode/src/drawobject.rs
+++ b/examples/paint-mode/src/drawobject.rs
@@ -1,7 +1,7 @@
 use embedded_graphics::{
     pixelcolor::Rgb888,
     prelude::*,
-    primitives::{circle::Circle, rectangle::Rectangle, triangle::Triangle, line::Line},
+    primitives::{circle::Circle, line::Line, rectangle::Rectangle, triangle::Triangle},
     style::{PrimitiveStyle, PrimitiveStyleBuilder, Styled},
 };
 
@@ -34,16 +34,30 @@ impl DrawObject {
             Self::Circ(circ) => circ.draw(disp).unwrap(),
             Self::Tri(tri) => tri.draw(disp).unwrap(),
             Self::Rect(rect) => rect.draw(disp).unwrap(),
-            Self::X(x) => { for line in x { line.draw(disp).unwrap(); } },
+            Self::X(x) => {
+                for line in x {
+                    line.draw(disp).unwrap();
+                }
+            }
         };
     }
 
     pub fn translate_mut(&mut self, point: Point) {
         match self {
-            Self::Circ(circ) => {circ.translate_mut(point);},
-            Self::Tri(tri) => {tri.translate_mut(point);},
-            Self::Rect(rect) => {rect.translate_mut(point);},
-            Self::X(x) => { for line in x { line.translate_mut(point); } },
+            Self::Circ(circ) => {
+                circ.translate_mut(point);
+            }
+            Self::Tri(tri) => {
+                tri.translate_mut(point);
+            }
+            Self::Rect(rect) => {
+                rect.translate_mut(point);
+            }
+            Self::X(x) => {
+                for line in x {
+                    line.translate_mut(point);
+                }
+            }
         };
     }
 
@@ -90,55 +104,55 @@ impl DrawObject {
         }
     }
 
+    pub fn move_by(&mut self, delta_x_pixels: i32, delta_y_pixels: i32, max_x: i32, max_y: i32) {
+        let existing_center = self.center();
+        let requested_delta = Point::new(delta_x_pixels, delta_y_pixels);
+        let mut target_location: Point = existing_center + requested_delta;
+        target_location.x = target_location.x.clamp(0, max_x);
+        target_location.y = target_location.y.clamp(0, max_y);
+        let actual_delta = target_location - existing_center;
+        self.translate_mut(actual_delta);
+    }
+
     pub fn new_circle(point: Point, size: u32) -> Self {
-        Self::Circ(Circle::new(point, size).into_styled(
-            PrimitiveStyleBuilder::new()
-                .stroke_color(Rgb888::RED)
-                .stroke_width(1)
-                .build(),
-        ))
+        Self::Circ(
+            Circle::new(point, size).into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Rgb888::RED)
+                    .stroke_width(1)
+                    .build(),
+            ),
+        )
     }
 
     pub fn new_triangle(point: Point, size: u32) -> Self {
-        let mut tri = Triangle::new(
-            point,
-            point,
-            point,
-        )
-        .into_styled(
+        let mut tri = Triangle::new(point, point, point).into_styled(
             PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb888::GREEN)
-            .stroke_width(1)
-            .build(),
+                .stroke_color(Rgb888::GREEN)
+                .stroke_width(1)
+                .build(),
         );
         grow_triangle_by(&mut tri, size as _);
         Self::Tri(tri)
     }
 
     pub fn new_rectangle(point: Point, size: u32) -> Self {
-        let mut rect = Rectangle::new(
-            point,
-            point,
-        )
-        .into_styled(
+        let mut rect = Rectangle::new(point, point).into_styled(
             PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb888::MAGENTA)
-            .stroke_width(1)
-            .build(),
+                .stroke_color(Rgb888::MAGENTA)
+                .stroke_width(1)
+                .build(),
         );
         grow_rectangle_by(&mut rect, size as _);
         Self::Rect(rect)
     }
 
     pub fn new_x(point: Point, size: u32) -> Self {
-        let line_1 = Line::new(
-            point,
-            point,
-        ).into_styled(
+        let line_1 = Line::new(point, point).into_styled(
             PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb888::BLUE)
-            .stroke_width(1)
-            .build(),
+                .stroke_color(Rgb888::BLUE)
+                .stroke_width(1)
+                .build(),
         );
         let line_2 = line_1.clone();
         let mut x = [line_1, line_2];

--- a/examples/paint-mode/src/lib.rs
+++ b/examples/paint-mode/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(clamp)]
 
 pub mod drawobject;
 pub use drawobject::DrawObject;

--- a/examples/paint-mode/src/lib.rs
+++ b/examples/paint-mode/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+pub mod drawobject;
+pub use drawobject::DrawObject;
+
+pub mod debug_textbox;
+pub use debug_textbox::draw_debug_textbox;
+
+pub mod background;
+pub use background::get_background;
+
+pub mod analog_stick_to_delta;
+pub use analog_stick_to_delta::convert_analog_to_delta_with_sensitivity_deadzone;

--- a/examples/paint-mode/src/main.rs
+++ b/examples/paint-mode/src/main.rs
@@ -33,7 +33,7 @@ fn psp_main() {
 
     unsafe {
         psp::sys::sceCtrlSetSamplingCycle(0);
-        psp::sys::sceCtrlSetSamplingMode(CtrlMode::Analaog);
+        psp::sys::sceCtrlSetSamplingMode(CtrlMode::Analog);
     };
 
     let pad_data = &mut get_empty_ctrl_data();

--- a/examples/paint-mode/src/main.rs
+++ b/examples/paint-mode/src/main.rs
@@ -1,0 +1,112 @@
+#![no_std]
+#![no_main]
+#![feature(slice_fill)]
+#![feature(clamp)]
+#![feature(exclusive_range_pattern)]
+#![feature(half_open_range_patterns)]
+
+use psp_paint_mode::{draw_debug_textbox, get_background, DrawObject};
+
+use embedded_graphics::prelude::*;
+
+use psp::embedded_graphics::Framebuffer;
+use psp::sys::{CtrlButtons, CtrlMode, SceCtrlData};
+use psp::{SCREEN_HEIGHT, SCREEN_WIDTH};
+
+psp::module!("Paint Mode Example", 0, 1);
+
+fn psp_main() {
+    psp::enable_home_button();
+
+    let disp = &mut Framebuffer::new();
+    let background = get_background();
+    let mut cur_size = 1;
+    let mut draw_obj = DrawObject::new_circle(get_midpoint(), cur_size);
+    let mut cur_location = draw_obj.center();
+
+    let mut i = 0;
+
+    background.draw(disp).unwrap();
+
+    unsafe {
+        psp::sys::sceCtrlSetSamplingCycle(0);
+        psp::sys::sceCtrlSetSamplingMode(CtrlMode::Analaog);
+    };
+
+    let pad_data = &mut get_empty_ctrl_data();
+    loop {
+        unsafe {
+            // Read button/analog input
+            psp::sys::sceCtrlReadBufferPositive(pad_data, 1);
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::START) {
+            // Wipe the screen
+            background.draw(disp).unwrap();
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::RTRIGGER) {
+            draw_obj.grow();
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::LTRIGGER) {
+            draw_obj.shrink();
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::CIRCLE) {
+            draw_obj = DrawObject::new_circle(cur_location, cur_size);
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::TRIANGLE) {
+            draw_obj = DrawObject::new_triangle(cur_location, cur_size);
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::SQUARE) {
+            draw_obj = DrawObject::new_rectangle(cur_location, cur_size);
+        }
+
+        if pad_data.buttons.contains(CtrlButtons::CROSS) {
+            draw_obj = DrawObject::new_x(cur_location, cur_size);
+        }
+
+        move_draw_obj(&mut draw_obj, pad_data);
+        cur_location = draw_obj.center();
+        cur_size = draw_obj.size();
+
+        if i < 10 {
+            i += 1;
+        } else {
+            draw_debug_textbox(disp, pad_data);
+            i = 0;
+        }
+
+        draw_obj.draw(disp);
+    }
+}
+
+fn get_empty_ctrl_data() -> SceCtrlData {
+    SceCtrlData {
+        timestamp: Default::default(),
+        buttons: CtrlButtons::empty(),
+        lx: Default::default(),
+        ly: Default::default(),
+        rsrv: Default::default(),
+    }
+}
+
+fn get_midpoint() -> Point {
+    Point::new(SCREEN_WIDTH as i32 / 2, SCREEN_HEIGHT as i32 / 2)
+}
+
+fn move_draw_obj(draw_obj: &mut DrawObject, pad_data: &SceCtrlData) {
+    let delta_x = convert_analog_to_delta_with_sensitivity_deadzone(pad_data.lx);
+    let delta_y = convert_analog_to_delta_with_sensitivity_deadzone(pad_data.ly);
+
+    let existing_center = draw_obj.center();
+    let requested_delta = Point::new(delta_x, delta_y);
+    let mut target_location: Point = existing_center + requested_delta;
+    target_location.x = target_location.x.clamp(0, SCREEN_WIDTH as i32);
+    target_location.y = target_location.y.clamp(0, SCREEN_HEIGHT as i32);
+    let actual_delta = target_location - existing_center;
+    draw_obj.translate_mut(actual_delta);
+}

--- a/examples/paint-mode/src/main.rs
+++ b/examples/paint-mode/src/main.rs
@@ -5,7 +5,10 @@
 #![feature(exclusive_range_pattern)]
 #![feature(half_open_range_patterns)]
 
-use psp_paint_mode::{draw_debug_textbox, get_background, DrawObject};
+use psp_paint_mode::{
+    convert_analog_to_delta_with_sensitivity_deadzone, draw_debug_textbox, get_background,
+    DrawObject,
+};
 
 use embedded_graphics::prelude::*;
 

--- a/psp/src/sys/ctrl.rs
+++ b/psp/src/sys/ctrl.rs
@@ -59,7 +59,7 @@ pub enum CtrlMode {
     /// Digital.
     Digital = 0,
     /// Analog.
-    Analaog
+    Analog
 }
 
 #[repr(C)]

--- a/psp/src/sys/ctrl.rs
+++ b/psp/src/sys/ctrl.rs
@@ -5,6 +5,7 @@ bitflags::bitflags! {
     ///
     /// Home, Note, Screen, VolUp, VolDown, Disc, WlanUp, Remote, and MS can only be
     /// read in kernel mode.
+    #[derive(Default)]
     pub struct CtrlButtons: u32 {
         /// Select button.
         const SELECT = 0x000001;
@@ -63,6 +64,7 @@ pub enum CtrlMode {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
 /// Returned controller data
 pub struct SceCtrlData {
     /// The current read frame.
@@ -78,6 +80,7 @@ pub struct SceCtrlData {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct SceCtrlLatch {
     pub ui_make: u32,
     pub ui_break: u32,


### PR DESCRIPTION
![Paint Mode](https://user-images.githubusercontent.com/145945/86718722-33bbac80-bfd8-11ea-97da-ccbf3ef98f7b.png)

A dead-simple paint program, using the four Playstation controller symbols+colors as brushes.

Controls:
* R/L: Increase/decrease brush size
* Start: Wipe screen
* Analog stick: Move
* Square/Triangle/etc: Change brush

Tinkered around with it long enough to feel like it was a worthy example for the repo - more than happy to polish it up however seems appropriate. Also happy to make it into a separate crate if that feels more appropriate (or more useful to have someone dogfooding a dependency on rust-psp).

Some highlights:
* Deadzone handling for analog stick (does this logic already exist somewhere?)
* Calculation of delta for moving objects on screen around with the analog stick in an intuitive manner
* Stack-based dynamic dispatch example with DrawObj
* Converting numbers to strings with numtoa, to be able to display analog stick values on-screen
* Example of stack-based conversion of slices of u8 to a &str (this was surprisingly difficult to figure out at first for someone without any no_std experience, but now it makes total sense - if you want an owned value on the stack, you need to allocate a known amount of memory to hold your values (in this case a fixed-length array))
