### PR TITLE
Add vfpu sin function and tests for it

### DIFF
--- a/ci/tests/src/main.rs
+++ b/ci/tests/src/main.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+#![feature(core_intrinsics)]
+
 #[cfg(not(feature = "stub-only"))] extern crate alloc;
 
 use psp::test_runner::TestRunner;

--- a/ci/tests/src/math_test.rs
+++ b/ci/tests/src/math_test.rs
@@ -1,14 +1,34 @@
 use psp::math;
+use psp::sys::GU_PI;
 use psp::test_runner::TestRunner;
+
+const EPSILON: f32 = 0.00001;
 
 pub fn test_main(test_runner: &mut TestRunner) {
     test_runner.check_list(&[
         ("cos_2.5", test_cos(2.5), -0.8011436),
         ("cos_0", test_cos(0.0), 1.0),
-        ("cos_pi", test_cos(psp::sys::GU_PI), -1.0),
+        ("cos_pi", test_cos(GU_PI), -1.0),
+        ("intrinsics_cos_pi", test_cos_intrinsic(GU_PI), -1.0),
+
+        ("sin_2.5", test_sin(2.5), 0.5984721),
     ]);
+    let almost_zero = test_sin_intrinsic(GU_PI);
+    test_runner.check_true("intrinsics_sin_0", almost_zero < EPSILON && almost_zero > -EPSILON);
 }
 
 fn test_cos(num: f32) -> f32 {
     unsafe { math::cosf32(num) }
+}
+
+fn test_cos_intrinsic(num: f32) -> f32 {
+    unsafe { core::intrinsics::cosf32(GU_PI) }
+}
+
+fn test_sin(num: f32) -> f32 {
+    unsafe { math::sinf32(num) }
+}
+
+fn test_sin_intrinsic(num: f32) -> f32 {
+    unsafe { core::intrinsics::sinf32(GU_PI) }
 }

--- a/ci/tests/src/math_test.rs
+++ b/ci/tests/src/math_test.rs
@@ -11,7 +11,10 @@ pub fn test_main(test_runner: &mut TestRunner) {
         ("cos_pi", test_cos(GU_PI), -1.0),
         ("intrinsics_cos_pi", test_cos_intrinsic(GU_PI), -1.0),
 
+        ("sin_0", test_sin(0), 0.0),
+        ("sin_pi", test_sin(GU_PI), 0.0),
         ("sin_2.5", test_sin(2.5), 0.5984721),
+        ("intrinsics_sin_2.5", test_sin_intrinsic(2.5), 0.5984721),
     ]);
     let almost_zero = test_sin_intrinsic(GU_PI);
     test_runner.check_true("intrinsics_sin_0", almost_zero < EPSILON && almost_zero > -EPSILON);
@@ -22,7 +25,7 @@ fn test_cos(num: f32) -> f32 {
 }
 
 fn test_cos_intrinsic(num: f32) -> f32 {
-    unsafe { core::intrinsics::cosf32(GU_PI) }
+    unsafe { core::intrinsics::cosf32(num) }
 }
 
 fn test_sin(num: f32) -> f32 {
@@ -30,5 +33,5 @@ fn test_sin(num: f32) -> f32 {
 }
 
 fn test_sin_intrinsic(num: f32) -> f32 {
-    unsafe { core::intrinsics::sinf32(GU_PI) }
+    unsafe { core::intrinsics::sinf32(num) }
 }

--- a/ci/tests/src/math_test.rs
+++ b/ci/tests/src/math_test.rs
@@ -1,5 +1,6 @@
 use psp::math;
-use psp::sys::GU_PI;
+//use psp::sys::GU_PI;
+use core::f32::consts::PI;
 use psp::test_runner::TestRunner;
 
 const EPSILON: f32 = 0.00001;
@@ -8,15 +9,15 @@ pub fn test_main(test_runner: &mut TestRunner) {
     test_runner.check_list(&[
         ("cos_2.5", test_cos(2.5), -0.8011436),
         ("cos_0", test_cos(0.0), 1.0),
-        ("cos_pi", test_cos(GU_PI), -1.0),
-        ("intrinsics_cos_pi", test_cos_intrinsic(GU_PI), -1.0),
+        ("cos_pi", test_cos(PI), -1.0),
+        ("intrinsics_cos_pi", test_cos_intrinsic(PI), -1.0),
 
         ("sin_0", test_sin(0.0), 0.0),
-        ("sin_pi", test_sin(GU_PI), 0.0),
+        ("sin_pi", test_sin(PI), 0.0),
         ("sin_2.5", test_sin(2.5), 0.5984721),
         ("intrinsics_sin_2.5", test_sin_intrinsic(2.5), 0.5984721),
     ]);
-    let almost_zero = test_sin_intrinsic(GU_PI);
+    let almost_zero = test_sin_intrinsic(PI);
     test_runner.check_true("intrinsics_sin_0", almost_zero < EPSILON && almost_zero > -EPSILON);
 }
 

--- a/ci/tests/src/math_test.rs
+++ b/ci/tests/src/math_test.rs
@@ -11,7 +11,7 @@ pub fn test_main(test_runner: &mut TestRunner) {
         ("cos_pi", test_cos(GU_PI), -1.0),
         ("intrinsics_cos_pi", test_cos_intrinsic(GU_PI), -1.0),
 
-        ("sin_0", test_sin(0), 0.0),
+        ("sin_0", test_sin(0.0), 0.0),
         ("sin_pi", test_sin(GU_PI), 0.0),
         ("sin_2.5", test_sin(2.5), 0.5984721),
         ("intrinsics_sin_2.5", test_sin_intrinsic(2.5), 0.5984721),

--- a/psp/src/math/trig.rs
+++ b/psp/src/math/trig.rs
@@ -1,23 +1,29 @@
 use core::mem::MaybeUninit;
 
+macro_rules! trig_func {
+    ( $($name:ident),* ) => {
+        $( item! {
+            #[allow(non_snake_case)]
+            #[no_mangle]
+            pub unsafe extern "C" fn [< $name f32 >](rad: f32) -> f32 {
+                let mut out = MaybeUninit::uninit();
 
-// TODO: cosf vs cosf32? which makes intrinsics::cosf32 work?
-#[allow(non_snake_case)]
-#[no_mangle]
-pub unsafe extern "C" fn cosf32(rad: f32) -> f32 {
-    let mut out = MaybeUninit::uninit();
+                $crate::vfpu_asm!(
+                    .mips "mfc1 $$t0, $1";
+                    mtv t0, S000;
+                    vcst_s S001, VFPU_2_PI;
+                    vmul_s S000, S000, S001;
+                    [< v $name _s>] S000, S000;
+                    mfv v0, S000;
+                    .mips "mtc1 $$v0, $1";
 
-    vfpu_asm!(
-        .mips "mfc1 $$t0, $1";
-        mtv t0, S000;
-        vcst_s S001, VFPU_2_PI;
-        vmul_s S000, S000, S001;
-        vcos_s S000, S000;
-        mfv v0, S000;
-        .mips "mtc1 $$v0, $1";
+                    : "={v0}"(out.as_mut_ptr()) : "{t0}"(rad) : "memory" : "volatile"
+                );
 
-        : "={v0}"(out.as_mut_ptr()) : "{t0}"(rad) : "memory" : "volatile"
-    );
-
-    out.assume_init()
+                out.assume_init()
+            }
+        })*
+    };
 }
+
+trig_func! {cos, sin}

--- a/psp/src/math/trig.rs
+++ b/psp/src/math/trig.rs
@@ -1,4 +1,5 @@
 use core::mem::MaybeUninit;
+use crate::sys::{vfpu_context::{Context, MatrixSet}, VFPU_CONTEXT};
 
 macro_rules! trig_func {
     ( $($name:ident),* ) => {
@@ -7,6 +8,9 @@ macro_rules! trig_func {
             #[no_mangle]
             pub unsafe extern "C" fn [< $name f32 >](rad: f32) -> f32 {
                 let mut out = MaybeUninit::uninit();
+                VFPU_CONTEXT
+                .get_or_insert_with(Context::new)
+                .prepare(MatrixSet::empty(), MatrixSet::VMAT0);
 
                 $crate::vfpu_asm!(
                     .mips "mfc1 $$t0, $1";

--- a/psp/src/sys/gum.rs
+++ b/psp/src/sys/gum.rs
@@ -59,7 +59,7 @@ static mut STACK_DEPTH: [*mut ScePspFMatrix4; 4] = unsafe {
     ]
 };
 
-static mut VFPU_CONTEXT: Option<Context> = None;
+pub(crate) static mut VFPU_CONTEXT: Option<Context> = None;
 unsafe fn get_context_unchecked() -> &'static mut Context {
     match VFPU_CONTEXT.as_mut() {
         Some(r) => r,

--- a/psp/src/test_runner.rs
+++ b/psp/src/test_runner.rs
@@ -15,7 +15,7 @@ use core::fmt::Arguments;
 pub struct TestRunner<'a> {
     mode: TestRunnerMode,
     failure: bool,
-    failures: Vec<&'a str>
+    failures: Vec<&'a str>,
 }
 
 enum TestRunnerMode {
@@ -88,6 +88,14 @@ impl<'a> TestRunner<'a> {
         }
     }
 
+    pub fn check_true(&mut self, testcase_name: &'a str, pred: bool) {
+        if pred {
+            self.pass(testcase_name, "True.");
+        } else {
+            self.fail(testcase_name, "False!");
+        }
+    }
+
     pub fn check_large_collection<T>(&mut self, testcase_name: &'a str, l: &[T], r: &[T])
     where
         T: core::fmt::Debug + PartialEq + Eq,
@@ -114,10 +122,7 @@ impl<'a> TestRunner<'a> {
                 i += 1;
             }
 
-            self.fail(
-                testcase_name,
-                "Collections were not equal!",
-            );
+            self.fail(testcase_name, "Collections were not equal!");
         }
     }
 


### PR DESCRIPTION
Looks like there isn't a tan func, so just sin for now. Also added a check that the cos/sin functions generated here work as the corresponding function in core::intrinsics.

I'll come up with a benchmark for these to see if the VFPU functions including travel time to/from the unit are actually faster than their mathematical equivalent on the CPU. If they really are substantially (or even marginally) faster than the equivalent calculation, I'll go through and generate similar functions for the other mathematical operations the VFPU offers.