### PR TITLE
Enable std builds (and retain ability to be no_std)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+Xargo.toml

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -130,12 +130,10 @@ fn main() {
 
     let xargo_toml = "\
         [target.mipsel-sony-psp.dependencies.core]\n\
-        [target.mipsel-sony-psp.dependencies.alloc]\n\
-        [target.mipsel-sony-psp.dependencies.panic_unwind]\n\
         stage = 1\n\
         [target.mipsel-sony-psp.dependencies.std]\n\
         stage = 2\n\
-        path = \"YOUR_PATH_HERE\"\n\
+        path = \"/home/glenn/rust-stdlib-potato/rust/src/libstd\"\n\
     ";
 
     fs::write("Xargo.toml", xargo_toml).unwrap();

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -133,6 +133,9 @@ fn main() {
         [target.mipsel-sony-psp.dependencies.alloc]\n\
         [target.mipsel-sony-psp.dependencies.panic_unwind]\n\
         stage = 1\n\
+        [target.mipsel-sony-psp.dependencies.std]\n\
+        stage = 2\n\
+        path = \"YOUR_PATH_HERE\"\n\
     ";
 
     fs::write("Xargo.toml", xargo_toml).unwrap();

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -128,13 +128,42 @@ fn main() {
     // Skip `cargo psp`
     let args = env::args().skip(2);
 
-    let xargo_toml = "\
-        [target.mipsel-sony-psp.dependencies.core]\n\
-        stage = 1\n\
-        [target.mipsel-sony-psp.dependencies.std]\n\
-        stage = 2\n\
-        path = \"/home/glenn/rust-stdlib-potato/rust/src/libstd\"\n\
-    ";
+    let xargo_toml = r#"
+[target.mipsel-sony-psp.dependencies.core]
+stage = 0
+
+#[target.mipsel-sony-psp.dependencies.compiler_builtins]
+#features = ["mem"]
+#stage = 1
+#path = "/home/glenn/rust-stdlib-potato/compiler-builtins"
+
+#[target.mipsel-sony-psp.dependencies.libc]
+#features = ["rustc-dep-of-std"]
+#stage = 2
+#path = "/home/glenn/rust-stdlib-potato/libc"
+
+[target.mipsel-sony-psp.dependencies.alloc]
+stage = 3
+
+[target.mipsel-sony-psp.dependencies.panic_unwind]
+stage = 4
+
+[target.mipsel-sony-psp.dependencies.std]
+stage = 5
+
+
+[patch.crates-io.libc]
+path = "/home/glenn/rust-stdlib-potato/libc"
+
+#[patch.crates-io.compiler_builtins]
+#path = "/home/glenn/rust-stdlib-potato/compiler-builtins"
+
+#[patch.crates-io.cfg-if]
+#path = "/home/glenn/rust-stdlib-potato/cfg-if"
+
+#[patch.crates-io.cc]
+#path = "/home/glenn/rust-stdlib-potato/cc-rs"
+"#;
 
     fs::write("Xargo.toml", xargo_toml).unwrap();
 

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -128,6 +128,14 @@ fn main() {
     // Skip `cargo psp`
     let args = env::args().skip(2);
 
+    // Power users can skip staging std for no_std builds.
+    let std_directive = match env::var("CARGO_PSP_NO_STD") {
+        Ok(_) => "",
+        _ => r#"[target.mipsel-sony-psp.dependencies.std]
+        stage = 3
+        "#,
+    };
+
     let libc_directive = match env::var("CARGO_PSP_LIBC") {
         Ok(loc) => format!(
             r#"[patch.crates-io.libc]
@@ -147,10 +155,12 @@ stage = 1
 [target.mipsel-sony-psp.dependencies.panic_unwind]
 stage = 2
 
-[target.mipsel-sony-psp.dependencies.std]
-stage = 3
+{std_directive}
+
 {libc_directive}
-"#, libc_directive=libc_directive);
+"#, 
+std_directive=std_directive,
+libc_directive=libc_directive);
 
 
     fs::write("Xargo.toml", xargo_toml).unwrap();

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -128,42 +128,30 @@ fn main() {
     // Skip `cargo psp`
     let args = env::args().skip(2);
 
-    let xargo_toml = r#"
+    let libc_directive = match env::var("CARGO_PSP_LIBC") {
+        Ok(loc) => format!(
+            r#"[patch.crates-io.libc]
+            path = "{}"
+            "#, loc),
+        _ => "".into()
+    };
+
+
+    let xargo_toml = format!(r#"
 [target.mipsel-sony-psp.dependencies.core]
 stage = 0
 
-#[target.mipsel-sony-psp.dependencies.compiler_builtins]
-#features = ["mem"]
-#stage = 1
-#path = "/home/glenn/rust-stdlib-potato/compiler-builtins"
-
-#[target.mipsel-sony-psp.dependencies.libc]
-#features = ["rustc-dep-of-std"]
-#stage = 2
-#path = "/home/glenn/rust-stdlib-potato/libc"
-
 [target.mipsel-sony-psp.dependencies.alloc]
-stage = 3
+stage = 1
 
 [target.mipsel-sony-psp.dependencies.panic_unwind]
-stage = 4
+stage = 2
 
 [target.mipsel-sony-psp.dependencies.std]
-stage = 5
+stage = 3
+{libc_directive}
+"#, libc_directive=libc_directive);
 
-
-[patch.crates-io.libc]
-path = "/home/glenn/rust-stdlib-potato/libc"
-
-#[patch.crates-io.compiler_builtins]
-#path = "/home/glenn/rust-stdlib-potato/compiler-builtins"
-
-#[patch.crates-io.cfg-if]
-#path = "/home/glenn/rust-stdlib-potato/cfg-if"
-
-#[patch.crates-io.cc]
-#path = "/home/glenn/rust-stdlib-potato/cc-rs"
-"#;
 
     fs::write("Xargo.toml", xargo_toml).unwrap();
 

--- a/examples/rust-std-hello-world/Cargo.toml
+++ b/examples/rust-std-hello-world/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-std"
+version = "0.1.0"
+authors = ["Glenn Hope <glenn.alexander.hope@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+psp = { path = "../../psp" }

--- a/examples/rust-std-hello-world/src/main.rs
+++ b/examples/rust-std-hello-world/src/main.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use std::string::String;
+
+psp::module!("rust_std_hello_world", 1, 1);
+
+fn psp_main() {
+    psp::enable_home_button();
+    let x = String::from("Hello, PSP!");
+    psp::dprint!("{}", x);
+}

--- a/examples/rust-std-hello-world/src/main.rs
+++ b/examples/rust-std-hello-world/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(restricted_std)]
 #![no_main]
 use std::string::String;
 
@@ -5,6 +6,11 @@ psp::module!("rust_std_hello_world", 1, 1);
 
 fn psp_main() {
     psp::enable_home_button();
-    let x = String::from("Hello, PSP!");
-    psp::dprint!("{}", x);
+    let people = vec!["sajattack", "overdrivenpotato", "iridescence"];
+    for person in people {
+        let x = format!("Hello, {}! I'm coming to you live from the standard library!\n", person);
+        psp::dprint!("{}", x);
+    }
+
+
 }

--- a/psp/Cargo.toml
+++ b/psp/Cargo.toml
@@ -16,6 +16,8 @@ build = "build.rs"
 crate-type = ["lib", "staticlib"]
 
 [features]
+default = ["std"]
+std = []
 # Compile this library as a stub provider. Useful to compile this as a static
 # library for other projects.
 stub-only = []

--- a/psp/src/alloc_impl.rs
+++ b/psp/src/alloc_impl.rs
@@ -54,8 +54,8 @@ unsafe impl GlobalAlloc for SystemAlloc {
 #[global_allocator]
 static ALLOC: SystemAlloc = SystemAlloc;
 
-#[alloc_error_handler]
-fn aeh(_: Layout) -> ! { loop {} }
+//#[alloc_error_handler]
+//fn aeh(_: Layout) -> ! { loop {} }
 
 #[no_mangle]
 #[cfg(not(feature = "stub-only"))]

--- a/psp/src/alloc_impl.rs
+++ b/psp/src/alloc_impl.rs
@@ -54,8 +54,9 @@ unsafe impl GlobalAlloc for SystemAlloc {
 #[global_allocator]
 static ALLOC: SystemAlloc = SystemAlloc;
 
-//#[alloc_error_handler]
-//fn aeh(_: Layout) -> ! { loop {} }
+#[cfg(not(feature = "std"))]
+#[alloc_error_handler]
+fn aeh(_: Layout) -> ! { loop {} }
 
 #[no_mangle]
 #[cfg(not(feature = "stub-only"))]

--- a/psp/src/lib.rs
+++ b/psp/src/lib.rs
@@ -7,7 +7,9 @@
     const_loop,
     const_if_match,
     const_generics,
+    restricted_std,
     c_variadic,
+    lang_items,
 )]
 
 // For unwinding support
@@ -16,8 +18,6 @@
 
 // For the `const_generics` feature.
 #![allow(incomplete_features)]
-
-#![no_std]
 
 #[macro_use] extern crate paste;
 #[cfg(not(feature = "stub-only"))] extern crate alloc;
@@ -47,9 +47,13 @@ pub mod vram_alloc;
 #[cfg(not(feature = "stub-only"))] mod constants;
 #[cfg(not(feature = "stub-only"))] pub use constants::*;
 
-#[cfg(feature = "stub-only")]
-#[panic_handler]
-fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+//#[cfg(feature = "stub-only")]
+//#[panic_handler]
+//fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern "C" fn rust_eh_personality() {}
 
 #[cfg(feature="embedded-graphics")]
 pub mod embedded_graphics;
@@ -150,7 +154,7 @@ macro_rules! module {
                 unsafe {
                     extern fn main_thread(_argc: usize, _argv: *mut c_void) -> i32 {
                         // TODO: Maybe print any error to debug screen?
-                        let _ = $crate::panic::catch_unwind(|| {
+                        let _ = std::panic::catch_unwind(|| {
                             super::psp_main();
                         });
 

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -20,11 +20,11 @@ fn print_and_die(s: String) -> ! {
     }
 }
 
-#[panic_handler]
-#[inline(never)]
-fn panic(info: &PanicInfo) -> ! {
-    panic_impl(info)
-}
+//#[panic_handler]
+//#[inline(never)]
+//fn panic(info: &PanicInfo) -> ! {
+//    panic_impl(info)
+//}
 
 #[inline(always)]
 #[cfg_attr(not(target_os = "psp"), allow(unused))]

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -20,14 +20,16 @@ fn print_and_die(s: String) -> ! {
     }
 }
 
-//#[panic_handler]
-//#[inline(never)]
-//fn panic(info: &PanicInfo) -> ! {
-//    panic_impl(info)
-//}
+#[cfg(not(feature = "std"))]
+#[panic_handler]
+#[inline(never)]
+fn panic(info: &PanicInfo) -> ! {
+    panic_impl(info)
+}
 
 #[inline(always)]
 #[cfg_attr(not(target_os = "psp"), allow(unused))]
+#[cfg(not(feature = "std"))]
 fn panic_impl(info: &PanicInfo) -> ! {
     struct PanicPayload<'a> {
         inner: &'a fmt::Arguments<'a>,
@@ -71,6 +73,7 @@ fn panic_impl(info: &PanicInfo) -> ! {
 /// Executes the primary logic for a panic, including checking for recursive
 /// panics, panic hooks, and finally dispatching to the panic runtime to either
 /// abort or unwind.
+#[cfg(not(feature = "std"))]
 fn rust_panic_with_hook(
     payload: &mut dyn BoxMeUp,
     message: Option<&fmt::Arguments<'_>>,


### PR DESCRIPTION
Changes:
* Environment variables to control Xargo.toml generation for `cargo psp`
* `Xargo.toml` in .gitignore, because I keep accidentally committing them
* std-aware example added to `examples/`
* Gating for all of the functions that are doubled from stdlib. I think there may be more we can gate away, but this is the MVP for getting a working `std`

Bits of this, especially around panics, feel like they could be a lot better, so very open to suggestions there if anything seems off.