### PR TITLE
Fix sceIoLseek and sceIoLseekAsync

### DIFF
--- a/psp/src/eabi.rs
+++ b/psp/src/eabi.rs
@@ -13,6 +13,16 @@ extern {
     ///
     /// This is not safe to call with a function that expects any other ABI.
     pub fn i7(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32, g: u32, ptr: extern fn(u32, u32, u32, u32, u32, u32, u32) -> u32) -> u32;
+
+    /// Call a function with the signature `fn(i32, i64, i32) -> i64` via the MIPS-EABI ABI.
+    ///
+    /// This is not safe to call with a function that expects any other ABI.
+    pub fn i_ii_i_rii(a: u32, b: u64, c: u32, ptr: extern fn(u32, u64, u32) -> u64) -> u64;
+
+    /// Call a function with the signature `fn(i32, i64, i32) -> i32` via the MIPS-EABI ABI.
+    ///
+    /// This is not safe to call with a function that expects any other ABI.
+    pub fn i_ii_i_ri(a: u32, b: u64, c: u32, ptr: extern fn(u32, u64, u32) -> u32) -> u32;
 }
 
 // Potential resource:
@@ -74,6 +84,21 @@ global_asm!(
 
             lw $t3, 60($sp)
             jalr $t3
+
+            lw $ra, 8($sp)
+            addiu $sp, 32
+            jr $ra
+
+        .global i_ii_i_rii
+        .global i_ii_i_ri
+        i_ii_i_rii:
+        i_ii_i_ri:
+            addiu $sp, -32
+            sw $ra, 8($sp)
+
+            lw $t0, 48($sp)
+            lw $t1, 52($sp)
+            jalr $t1
 
             lw $ra, 8($sp)
             addiu $sp, 32

--- a/psp/src/sys/io.rs
+++ b/psp/src/sys/io.rs
@@ -1,6 +1,6 @@
 use crate::sys::SceUid;
 use crate::sys::ScePspDateTime;
-use crate::eabi::i6;
+use crate::eabi::{i6, i_ii_i_rii, i_ii_i_ri};
 use core::ffi::c_void;
 
 /// Describes a single directory entry
@@ -243,7 +243,7 @@ psp_extern! {
     pub fn sceIoWriteAsync(fd: SceUid, data: *const c_void, size: u32)
      -> i32;
 
-    #[psp(0x27EB27B8)]
+    #[psp(0x27EB27B8, i_ii_i_rii)]
     /// Reposition read/write file descriptor offset
     ///
     /// # Parameters
@@ -259,7 +259,7 @@ psp_extern! {
     /// The position in the file after the seek.
     pub fn sceIoLseek(fd: SceUid, offset: i64, whence: IoWhence) -> i64;
 
-    #[psp(0x71B19E77)]
+    #[psp(0x71B19E77, i_ii_i_ri)]
     /// Reposition read/write file descriptor offset (asynchronous)
     ///
     /// # Parameters


### PR DESCRIPTION
This PR adds 2 new EABI -> o32 mappers, which are (so far) only used by `sceIoLseek` and `sceIoLseekAsync`. Those 2 functions should now work correctly.