### PR TITLE
Add foreign exception function

### DIFF
--- a/psp/src/lib.rs
+++ b/psp/src/lib.rs
@@ -54,6 +54,9 @@ pub mod sys;
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
 
+#[no_mangle]
+extern "C" fn __rust_foreign_exception() -> ! { loop {} }
+
 #[cfg(feature = "std")]
 pub use std::panic::catch_unwind;
 


### PR DESCRIPTION
The need for this function was added in https://github.com/rust-lang/rust/pull/70212

I'm not sure if this is exactly what we want, or if we want to pass this to our own catch_unwind - but putting up a PR to fix compilation regardless. Neither std nor no_std builds will successfully compile on nightly right now.