### PR TITLE
removed duplicate code from embedded-graphics example

### DIFF
--- a/examples/embedded-graphics/src/main.rs
+++ b/examples/embedded-graphics/src/main.rs
@@ -23,19 +23,6 @@ fn psp_main() {
         .build();
     let black_backdrop = Rectangle::new(Point::new(0, 0), Point::new(160, 80)).into_styled(style);
     black_backdrop.draw(&mut disp).unwrap();
-    Triangle::new(
-        Point::new(8, 66 + 16),
-        Point::new(8 + 16, 66 + 16),
-        Point::new(8 + 8, 66),
-    )
-    .into_styled(
-        PrimitiveStyleBuilder::new()
-            .stroke_color(Rgb888::RED)
-            .stroke_width(1)
-            .build(),
-    )
-    .draw(&mut disp)
-    .unwrap();
 
     // draw ferris
     let bmp = Bmp::from_slice(include_bytes!("../assets/ferris.bmp")).unwrap();


### PR DESCRIPTION
Embedded-graphics example shows off drawing an image, some shapes, and a string to the screen. Reading through the code, it appeared to be drawing the triangle twice - once earlier on in the program, and once at the same time as drawing the circle and the square. After removing the first triangle, a test build appeared to work exactly the same, so I assume it was a mistake.