### PR TITLE
Add `SimpleVramAllocator::free_all` and attach a lifetime to VRAM chunks

### DIFF
--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -89,18 +89,21 @@ unsafe fn psp_main_inner() {
     psp::enable_home_button();
 
     let mut allocator = get_vram_allocator().unwrap();
-    let fbp0 = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm8888).as_mut_ptr_from_zero();
-    let fbp1 = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm8888).as_mut_ptr_from_zero();
-    let zbp = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm4444).as_mut_ptr_from_zero();
+    let fbp0 = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm8888);
+    let fbp1 = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm8888);
+    let zbp = allocator.alloc_texture_pixels(BUF_WIDTH, SCREEN_HEIGHT, TexturePixelFormat::Psm4444);
+    // Attempting to free the three VRAM chunks at this point would give a
+    // compile-time error since fbp0, fbp1 and zbp are used later on
+    //allocator.free_all();
 
     sys::sceGumLoadIdentity();
 
     sys::sceGuInit();
 
     sys::sceGuStart(GuContextType::Direct, &mut LIST.0 as *mut [u32; 0x40000] as *mut _);
-    sys::sceGuDrawBuffer(DisplayPixelFormat::Psm8888, fbp0 as _, BUF_WIDTH as i32);
-    sys::sceGuDispBuffer(SCREEN_WIDTH as i32, SCREEN_HEIGHT as i32, fbp1 as _, BUF_WIDTH as i32);
-    sys::sceGuDepthBuffer(zbp as _, BUF_WIDTH as i32);
+    sys::sceGuDrawBuffer(DisplayPixelFormat::Psm8888, fbp0.as_mut_ptr_from_zero() as _, BUF_WIDTH as i32);
+    sys::sceGuDispBuffer(SCREEN_WIDTH as i32, SCREEN_HEIGHT as i32, fbp1.as_mut_ptr_from_zero() as _, BUF_WIDTH as i32);
+    sys::sceGuDepthBuffer(zbp.as_mut_ptr_from_zero() as _, BUF_WIDTH as i32);
     sys::sceGuOffset(2048 - (SCREEN_WIDTH / 2), 2048 - (SCREEN_HEIGHT / 2));
     sys::sceGuViewport(2048, 2048, SCREEN_WIDTH as i32, SCREEN_HEIGHT as i32);
     sys::sceGuDepthRange(65535, 0);


### PR DESCRIPTION
This allows the borrow checker to work with VRAM allocations like I mentioned on discord. I don't think it's super-useful with the current sceGu API, but it doesn't seem any more cumbersome to use which is what I was mainly concerned about. The issue with sceGu is that it takes pointers as arguments so the VRAM chunk lifetime provides no benefit in this particular case

```
// Borrow the allocator for 'a, get a VRAMChunk<'a> then get a pointer to the
// chunk and drop the VRAMChunk<'a>
let chunk_ptr = allocator.alloc(size).as_mut_ptr();

// Mutably borrowing the allocator for 'b is fine since VRAMChunk<'a> was
// already dropped
allocator.free_all();

// Allocates another chunk overlapping the first one. This is allowed because
// chunk_ptr doesn't have a lifetime and VRAMChunk<'a> was dropped.
let new_chunk = allocator.alloc(size);

// Use-after-free
sceGuDrawBuffer(chunk_ptr);
```

For this to be useful, you'd have to keep the VRAMChunk<'a> until it's passed to `sceGuDrawBuffer` like in the PR example. Or we could make a sceGu API that accepts `VRAMChunks` and calculates the pointer internally.

Also the `AtomicU32` in the allocator is just for interior mutability (could've been Cell or RefCell). It doesn't inherently make the allocator thread-safe, but the demos use a singleton anyway so it doesn't matter.