### PR TITLE
`cargo-psp` workspace support

### DIFF
--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -216,7 +216,6 @@ fn main() {
         let output = Command::new(cargo)
             .arg("metadata")
             .arg("--format-version=1")
-            .arg("--offline")
             .arg("-Z")
             .arg(build_std_flag)
             .stderr(Stdio::inherit())

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -212,15 +212,41 @@ fn main() {
         .spawn()
         .unwrap();
 
-    let metadata_process = Command::new(cargo)
-        .arg("metadata")
-        .arg("--format-version=1")
-        .arg("--offline")
-        .arg("-Z")
-        .arg(build_std_flag)
-        .stdout(Stdio::piped())
-        .spawn()
-        .unwrap();
+    let lone = {
+        let output = Command::new(cargo)
+            .arg("metadata")
+            .arg("--format-version=1")
+            .arg("--offline")
+            .arg("-Z")
+            .arg(build_std_flag)
+            .stderr(Stdio::inherit())
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            panic!(
+                "`cargo metadata` command exited with status: {:?}",
+                output.status
+            );
+        }
+
+        let metadata = MetadataCommand::parse(
+            std::str::from_utf8(&output.stdout)
+                .expect("`cargo metadata` command returned non UTF-8 bytes"),
+        )
+        .expect("failed to parse `cargo metadata` command's stdout");
+
+        let workspace_members: HashSet<_> = metadata.workspace_members.iter().collect();
+        let total_executables = metadata
+            .packages
+            .iter()
+            .filter(|p| workspace_members.contains(&p.id))
+            .flat_map(|p| &p.targets)
+            .filter(|t| t.crate_types.iter().any(|ct| *ct == "bin"))
+            .count();
+
+        total_executables == 1
+    };
 
     let reader = std::io::BufReader::new(build_process.stdout.take().unwrap());
     let built_executables: Vec<_> = CargoMessage::parse_stream(reader)
@@ -230,36 +256,11 @@ fn main() {
         })
         .collect();
 
-    let output = metadata_process.wait_with_output().unwrap();
-    if !output.status.success() {
-        panic!(
-            "`cargo metadata` command exited with status: {:?}",
-            output.status
-        );
-    }
-
-    let metadata = MetadataCommand::parse(
-        std::str::from_utf8(&output.stdout)
-            .expect("`cargo metadata` command returned non UTF-8 bytes"),
-    )
-    .expect("failed to parse `cargo metadata` command's stdout");
-
-    let workspace_members: HashSet<_> = metadata.workspace_members.iter().collect();
-    let total_executables = metadata
-        .packages
-        .iter()
-        .filter(|p| workspace_members.contains(&p.id))
-        .flat_map(|p| &p.targets)
-        .filter(|t| t.crate_types.iter().any(|ct| *ct == "bin"))
-        .count();
-
     let status = build_process.wait().unwrap();
     if !status.success() {
         eprintln!("`cargo build` command exited with status: {:?}", status);
         process::exit(status.code().unwrap_or(1));
     }
-
-    let lone = total_executables == 1;
 
     // TODO: Error if no bin is ever found.
     for elf_path in built_executables {

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -1,5 +1,5 @@
 use cargo_metadata::Message as CargoMessage;
-use rustc_version::{Version, Channel};
+use rustc_version::{Channel, Version};
 use std::{
     env, fmt, fs,
     io::ErrorKind,
@@ -224,7 +224,6 @@ fn main() {
         process::exit(status.code().unwrap_or(1));
     }
 
-
     // TODO: Error if no bin is ever found.
     for elf_path in executables {
         let prx_path = elf_path.with_extension("prx");
@@ -244,7 +243,11 @@ fn main() {
             ("-s", "DISC_ID", config.disc_id.clone()),
             ("-s", "DISC_VERSION", config.disc_version.clone()),
             ("-s", "LANGUAGE", config.language.clone()),
-            ("-d", "PARENTAL_LEVEL", config.parental_level.as_ref().map(u32::to_string)),
+            (
+                "-d",
+                "PARENTAL_LEVEL",
+                config.parental_level.as_ref().map(u32::to_string),
+            ),
             ("-s", "PSP_SYSTEM_VER", config.psp_system_ver.clone()),
             ("-d", "REGION", config.region.as_ref().map(u32::to_string)),
             ("-s", "TITLE_0", config.title_jp.clone()),
@@ -263,17 +266,19 @@ fn main() {
             .args({
                 config_args
                     .into_iter()
-
                     // Filter through all the values that are not `None`
                     .filter_map(|(f, k, v)| v.map(|v| (f, k, v)))
-
                     // Map into 2 arguments, e.g. "-s" "NAME=VALUE"
-                    .flat_map(|(flag, key, value)| vec![
-                        flag.into(),
-                        format!("{}={}", key, value),
-                    ])
+                    .flat_map(|(flag, key, value)| vec![flag.into(), format!("{}={}", key, value)])
             })
-            .arg(config.title.as_ref().map(|s| s.as_ref()).or_else(|| elf_path.file_stem()).unwrap())
+            .arg(
+                config
+                    .title
+                    .as_ref()
+                    .map(|s| s.as_ref())
+                    .or_else(|| elf_path.file_stem())
+                    .unwrap(),
+            )
             .arg(&sfo_path)
             .status()
             .expect("failed to run mksfo");

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -224,12 +224,19 @@ fn main() {
         process::exit(status.code().unwrap_or(1));
     }
 
+    let lone = executables.len() == 1;
+
     // TODO: Error if no bin is ever found.
     for elf_path in executables {
         let prx_path = elf_path.with_extension("prx");
 
-        let sfo_path = elf_path.with_extension("param.sfo");
-        let pbp_path = elf_path.with_extension("eboot.pbp");
+        let [sfo_path, pbp_path] = ["PARAM.SFO", "EBOOT.PBP"].map(|e| {
+            if lone {
+                elf_path.with_file_name(e)
+            } else {
+                elf_path.with_extension(e)
+            }
+        });
 
         fix_imports::fix(&elf_path);
 


### PR DESCRIPTION
Fixes #139 #146 

Introduces workspace support, crate examples support. Also fixes `--manifest-path`.

Workspace changes i plan to publish as a separate PR.
