### PR TITLE
Fix clippy warnings for `psp`

### DIFF
--- a/psp/src/alloc_impl.rs
+++ b/psp/src/alloc_impl.rs
@@ -55,7 +55,9 @@ static ALLOC: SystemAlloc = SystemAlloc;
 #[cfg(not(feature = "std"))]
 #[alloc_error_handler]
 fn aeh(_: Layout) -> ! {
-    loop {}
+    loop {
+        core::hint::spin_loop()
+    }
 }
 
 #[no_mangle]

--- a/psp/src/debug.rs
+++ b/psp/src/debug.rs
@@ -60,9 +60,7 @@ impl Font for MsxFont {
 
     fn put_char(x: usize, y: usize, color: u32, c: u8) {
         unsafe {
-            let mut ptr = VRAM_BASE
-                .offset(x as isize)
-                .offset((y * BUFFER_WIDTH) as isize);
+            let mut ptr = VRAM_BASE.add(x + y * BUFFER_WIDTH);
 
             for i in 0..8 {
                 for j in 0..8 {
@@ -73,7 +71,7 @@ impl Font for MsxFont {
                     ptr = ptr.offset(1);
                 }
 
-                ptr = ptr.offset(-8).offset(BUFFER_WIDTH as isize);
+                ptr = ptr.add(BUFFER_WIDTH - 8);
             }
         }
     }

--- a/psp/src/lib.rs
+++ b/psp/src/lib.rs
@@ -66,13 +66,17 @@ pub use unstringify::unstringify;
 #[cfg(feature = "stub-only")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        core::hint::spin_loop()
+    }
 }
 
 #[cfg(not(feature = "std"))]
 #[no_mangle]
 extern "C" fn __rust_foreign_exception() -> ! {
-    loop {}
+    loop {
+        core::hint::spin_loop()
+    }
 }
 
 #[cfg(feature = "std")]

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -66,7 +66,7 @@ fn panic_impl(info: &PanicInfo) -> ! {
             let inner = self.inner;
             self.string.get_or_insert_with(|| {
                 let mut s = String::new();
-                drop(s.write_fmt(*inner));
+                let _ = s.write_fmt(*inner);
                 s
             })
         }

--- a/psp/src/screenshot.rs
+++ b/psp/src/screenshot.rs
@@ -46,9 +46,9 @@ fn rgb565_to_bgra(rgb565: u16) -> u32 {
     let rgb565 = rgb565 as u32;
 
     // bbbb bggg gggr rrrr -> 0xffRRGGBB
-    ((rgb565 & 0x1f) << 16) * 0x100 / 0x20
-        | ((rgb565 & 0x7e0) << 3) * 0x100 / 0x40
-        | ((rgb565 & 0xf800) >> 11) * 0x100 / 0x20
+    (((rgb565 & 0x1f) << 16) * 0x100 / 0x20)
+        | (((rgb565 & 0x7e0) << 3) * 0x100 / 0x40)
+        | (((rgb565 & 0xf800) >> 11) * 0x100 / 0x20)
         | 0xff00_0000
 }
 
@@ -56,20 +56,20 @@ fn rgba5551_to_bgra(rgba5551: u16) -> u32 {
     let rgba5551 = rgba5551 as u32;
 
     // abbb bbgg gggr rrrr -> 0xAARRGGBB
-    ((rgba5551 & 0x1f) << 16) * 0x100 / 0x20
-        | ((rgba5551 & 0x3e0) << 3) * 0x100 / 0x20
-        | ((rgba5551 & 0x7c00) >> 10) * 0x100 / 0x20
-        | ((rgba5551 & 0x8000) >> 15) * 0xff00_0000
+    (((rgba5551 & 0x1f) << 16) * 0x100 / 0x20)
+        | (((rgba5551 & 0x3e0) << 3) * 0x100 / 0x20)
+        | (((rgba5551 & 0x7c00) >> 10) * 0x100 / 0x20)
+        | (((rgba5551 & 0x8000) >> 15) * 0xff00_0000)
 }
 
 fn rgba4444_to_bgra(rgba4444: u16) -> u32 {
     let rgba4444 = rgba4444 as u32;
 
     // aaaa bbbb gggg rrrr -> 0xAARRGGBB
-    ((rgba4444 & 0x000f) << 16) * 0x100 / 0x10
-        | ((rgba4444 & 0x00f0) << 4) * 0x100 / 0x10
-        | ((rgba4444 & 0x0f00) >> 8) * 0x100 / 0x10
-        | ((rgba4444 & 0xf000) << 12) * 0x100 / 0x10
+    (((rgba4444 & 0x000f) << 16) * 0x100 / 0x10)
+        | (((rgba4444 & 0x00f0) << 4) * 0x100 / 0x10)
+        | (((rgba4444 & 0x0f00) >> 8) * 0x100 / 0x10)
+        | (((rgba4444 & 0xf000) << 12) * 0x100 / 0x10)
 }
 
 /// Take a screenshot, returning a raw ARGB (big-endian) array.

--- a/psp/src/screenshot.rs
+++ b/psp/src/screenshot.rs
@@ -8,6 +8,7 @@ const BYTES_PER_PIXEL: usize = 4;
 const NUM_PIXELS: usize = (SCREEN_WIDTH * SCREEN_HEIGHT) as usize;
 
 #[repr(C, packed)]
+#[derive(Clone, Copy)]
 struct BmpHeader {
     pub file_type: [u8; 2],
     pub file_size: u32,

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -2190,7 +2190,7 @@ pub unsafe extern "C" fn sceGuDisable(state: GuState) {
             send_command_i(GeCommand::Scissor1, 0);
             send_command_i(
                 GeCommand::Scissor2,
-                ((DRAW_BUFFER.height - 1) << 10) | DRAW_BUFFER.width - 1,
+                ((DRAW_BUFFER.height - 1) << 10) | (DRAW_BUFFER.width - 1),
             );
         }
         GuState::StencilTest => send_command_i(GeCommand::StencilTestEnable, 0),

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -8,6 +8,7 @@ use crate::sys::{
 use core::{ffi::c_void, mem, ptr::null_mut};
 use num_enum::TryFromPrimitive;
 
+#[allow(clippy::approx_constant)]
 pub const GU_PI: f32 = 3.141593;
 
 /// Primitive types

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -3650,12 +3650,12 @@ pub unsafe extern "C" fn sceGuDebugFlush() {
                         x_pixel_counter -= 1;
                         glyph_pos <<= 1;
                         pos += 4;
-                        if !(-1 < x_pixel_counter) {
+                        if x_pixel_counter <= -1 {
                             break;
                         }
                     }
                     y_pixel_counter += 1;
-                    if !(y_pixel_counter < 8) {
+                    if 8 <= y_pixel_counter {
                         break;
                     }
                 }

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -3552,35 +3552,35 @@ pub unsafe extern "C" fn sceGuDebugPrint(x: i32, mut y: i32, mut color: u32, mut
             uVar1 = (iVar4 as u32) << 0xb;
             uVar1 = (uVar1 | iVar2 as u32) << 5;
             color = (color & 0xff) >> 3;
-            color = uVar1 | color;
+            color |= uVar1;
         }
         DisplayPixelFormat::Psm5551 => {
             iVar2 = (uVar1 >> 3) as i32;
             uVar1 = (((color >> 24) >> 7) << 0xf | (iVar4 as u32) << 10) as u32;
             uVar1 = (uVar1 | iVar2 as u32) << 5;
             color = (color & 0xff) >> 3;
-            color = uVar1 | color;
+            color |= uVar1;
         }
         DisplayPixelFormat::Psm8888 => {}
         DisplayPixelFormat::Psm4444 => {
             uVar1 = ((color >> 0x18) >> 4) << 0xc | (uVar3 >> 4) << 8 | (uVar1 >> 4) << 4;
-            color = color & 0xff >> 4;
-            color = uVar1 | color;
+            color &= 0xff >> 4;
+            color |= uVar1;
         }
     }
     cur_char = *msg;
     while cur_char != b'\0' {
         if cur_char == b'\n' {
-            y = y + 8;
+            y += 8;
             cur_x = x;
         } else {
             (*char_struct_ptr).x = cur_x;
-            i = i + 1;
+            i += 1;
             (*char_struct_ptr).character = cur_char - 0x20;
             (*char_struct_ptr).y = y;
             (*char_struct_ptr).color = color;
             char_struct_ptr = (char_struct_ptr as u32 + 16) as *mut DebugCharStruct;
-            cur_x = cur_x + 8;
+            cur_x += 8;
         }
         msg = msg.add(1);
         cur_char = *msg;
@@ -3650,9 +3650,9 @@ pub unsafe extern "C" fn sceGuDebugFlush() {
                                 *((pos as u32 + 0x4000_0002) as *mut u16) = color as u16;
                             }
                         }
-                        x_pixel_counter = x_pixel_counter - 1;
-                        glyph_pos = glyph_pos << 1;
-                        pos = pos + 4;
+                        x_pixel_counter -= 1;
+                        glyph_pos <<= 1;
+                        pos += 4;
                         if !(-1 < x_pixel_counter) {
                             break;
                         }
@@ -3663,7 +3663,7 @@ pub unsafe extern "C" fn sceGuDebugFlush() {
                     }
                 }
             }
-            char_buffer_used = char_buffer_used - 1;
+            char_buffer_used -= 1;
             char_struct_ptr = ((char_struct_ptr as u32) + 16) as *mut DebugCharStruct;
             if char_buffer_used == 0 {
                 break;

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -868,7 +868,7 @@ unsafe fn send_command_i(cmd: GeCommand, argument: i32) {
 
 #[inline]
 unsafe fn send_command_f(cmd: GeCommand, argument: f32) {
-    send_command_i(cmd, (core::mem::transmute::<_, u32>(argument) >> 8) as i32);
+    send_command_i(cmd, (argument.to_bits() >> 8) as i32);
 }
 
 #[inline]

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -2348,7 +2348,6 @@ pub unsafe extern "C" fn sceGuLightSpot(
 #[no_mangle]
 pub unsafe extern "C" fn sceGuClear(flags: ClearBuffer) {
     let context = &mut CONTEXTS[CURR_CONTEXT as usize];
-    let filter: u32;
 
     struct Vertex {
         color: u32,
@@ -2358,18 +2357,18 @@ pub unsafe extern "C" fn sceGuClear(flags: ClearBuffer) {
         _pad: u16,
     }
 
-    match DRAW_BUFFER.pixel_size {
-        DisplayPixelFormat::Psm5650 => filter = context.clear_color & 0xffffff,
+    let filter: u32 = match DRAW_BUFFER.pixel_size {
+        DisplayPixelFormat::Psm5650 => context.clear_color & 0xffffff,
         DisplayPixelFormat::Psm5551 => {
-            filter = (context.clear_color & 0xffffff) | (context.clear_stencil << 31);
+            (context.clear_color & 0xffffff) | (context.clear_stencil << 31)
         }
         DisplayPixelFormat::Psm4444 => {
-            filter = (context.clear_color & 0xffffff) | (context.clear_stencil << 28);
+            (context.clear_color & 0xffffff) | (context.clear_stencil << 28)
         }
         DisplayPixelFormat::Psm8888 => {
-            filter = (context.clear_color & 0xffffff) | (context.clear_stencil << 24);
+            (context.clear_color & 0xffffff) | (context.clear_stencil << 24)
         }
-    }
+    };
 
     let vertices;
     let count;
@@ -3532,8 +3531,6 @@ pub unsafe extern "C" fn sceGuDebugPrint(x: i32, mut y: i32, mut color: u32, mut
     let mut cur_char: u8;
     let mut uVar1: u32;
     let iVar2: i32;
-    let uVar3: u32;
-    let iVar4: i32;
     let mut cur_x: i32;
     let mut char_struct_ptr: *mut DebugCharStruct =
         &mut CHAR_BUFFER as *mut _ as *mut DebugCharStruct;
@@ -3543,8 +3540,8 @@ pub unsafe extern "C" fn sceGuDebugPrint(x: i32, mut y: i32, mut color: u32, mut
         return;
     }
     uVar1 = color >> 8 & 0xff;
-    uVar3 = color >> 16 & 0xff;
-    iVar4 = (uVar3 >> 3) as i32;
+    let uVar3 = color >> 16 & 0xff;
+    let iVar4 = (uVar3 >> 3) as i32;
     cur_x = x;
     match DRAW_BUFFER.pixel_size {
         DisplayPixelFormat::Psm5650 => {

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -1025,7 +1025,7 @@ pub unsafe extern "C" fn sceGuDispBuffer(
         DRAW_BUFFER.height as usize,
     );
 
-    if DISPLAY_ON == true {
+    if DISPLAY_ON {
         crate::sys::sceDisplaySetFrameBuf(
             (GE_EDRAM_ADDRESS as *mut u8).add(DRAW_BUFFER.disp_buffer as usize),
             dispbw as usize,

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -3625,12 +3625,10 @@ pub unsafe extern "C" fn sceGuDebugFlush() {
                         font_glyph =
                             *(((&FONT as *const _ as u32) + char_index as u32) as *const u32);
                         glyph_pos = 1;
-                    } else {
-                        if y_pixel_counter == 4 {
-                            font_glyph = *(((&FONT as *const _ as u32) + 4 + char_index as u32)
-                                as *const u32);
-                            glyph_pos = 1
-                        }
+                    } else if y_pixel_counter == 4 {
+                        font_glyph =
+                            *(((&FONT as *const _ as u32) + 4 + char_index as u32) as *const u32);
+                        glyph_pos = 1
                     }
                     x_pixel_counter = 7;
                     pos = x + (y + y_pixel_counter) * frame_width;

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -1873,9 +1873,11 @@ pub unsafe extern "C" fn sceGuSendList(
 ) {
     SETTINGS.signal_offset = 0;
 
-    let mut args = GeListArgs::default();
-    args.size = 8;
-    args.context = context;
+    let mut args = GeListArgs {
+        size: 8,
+        context,
+        ..<_>::default()
+    };
 
     let callback = SETTINGS.ge_callback_id;
 

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -1187,9 +1187,7 @@ pub unsafe extern "C" fn sceGuDepthRange(mut near: i32, mut far: i32) {
     send_command_f(GeCommand::ViewportZCenter, z + context.depth_offset as f32);
 
     if near > far {
-        let temp = near;
-        near = far;
-        far = temp;
+        mem::swap(&mut near, &mut far);
     }
 
     send_command_i(GeCommand::MinZ, near);

--- a/psp/src/sys/gu.rs
+++ b/psp/src/sys/gu.rs
@@ -903,8 +903,7 @@ unsafe fn reset_values() {
     DRAW_BUFFER.width = 480;
     DRAW_BUFFER.height = 272;
 
-    for i in 0..3 {
-        let context = &mut CONTEXTS[i];
+    for context in &mut CONTEXTS {
         context.scissor_enable = 0;
         context.scissor_start = [0, 0];
         context.scissor_end = [0, 0];

--- a/psp/src/sys/gum.rs
+++ b/psp/src/sys/gum.rs
@@ -717,7 +717,7 @@ unsafe fn gum_look_at(
 
     gum_normalize(&mut forward);
 
-    let mut side = gum_cross_product(&forward, &up);
+    let mut side = gum_cross_product(&forward, up);
     gum_normalize(&mut side);
 
     let lup = gum_cross_product(&side, &forward);

--- a/psp/src/sys/macros.rs
+++ b/psp/src/sys/macros.rs
@@ -181,7 +181,7 @@ macro_rules! psp_extern {
                     }
 
                     $(#[$attr])*
-                    #[allow(non_snake_case)]
+                    #[allow(non_snake_case, clippy::missing_safety_doc)]
                     #[no_mangle]
                     pub unsafe extern fn $name($($arg : $arg_ty),*) $(-> $ret)? {
                         #[cfg(target_os = "psp")]

--- a/psp/src/sys/mod.rs
+++ b/psp/src/sys/mod.rs
@@ -27,6 +27,8 @@
 //!     - `sceOpenPSID`: Console identification API (unique to every console)
 //!     - `sceUtility`: Various utilities such as msg dialogs and savedata
 
+#![allow(clippy::missing_safety_doc)]
+
 use core::{mem, ptr};
 
 #[macro_use]

--- a/psp/src/sys/vfpu_context.rs
+++ b/psp/src/sys/vfpu_context.rs
@@ -137,3 +137,9 @@ impl Context {
         }
     }
 }
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/psp/src/test_runner.rs
+++ b/psp/src/test_runner.rs
@@ -19,8 +19,8 @@ pub struct TestRunner<'a> {
 }
 
 enum TestRunnerMode {
-    FIFO(SceUid),
-    FILE(SceUid),
+    Fifo(SceUid),
+    File(SceUid),
     Dprintln,
 }
 
@@ -28,7 +28,7 @@ impl<'a> TestRunner<'a> {
     pub fn new_fifo_runner() -> Self {
         let fd = get_test_output_pipe();
         Self {
-            mode: TestRunnerMode::FIFO(fd),
+            mode: TestRunnerMode::Fifo(fd),
             failure: false,
             failures: Vec::new(),
         }
@@ -37,7 +37,7 @@ impl<'a> TestRunner<'a> {
     pub fn new_file_runner() -> Self {
         let fd = get_test_output_file();
         Self {
-            mode: TestRunnerMode::FILE(fd),
+            mode: TestRunnerMode::File(fd),
             failure: false,
             failures: Vec::new(),
         }
@@ -173,7 +173,7 @@ impl<'a> TestRunner<'a> {
 
     pub fn write_args(&self, args: Arguments) {
         match self.mode {
-            TestRunnerMode::FILE(fd) | TestRunnerMode::FIFO(fd) => {
+            TestRunnerMode::File(fd) | TestRunnerMode::Fifo(fd) => {
                 write_to_psp_output_fd(fd, &format!("{}", args));
             }
             TestRunnerMode::Dprintln => {
@@ -184,7 +184,7 @@ impl<'a> TestRunner<'a> {
 
     fn quit(self) {
         match self.mode {
-            TestRunnerMode::FILE(fd) | TestRunnerMode::FIFO(fd) => {
+            TestRunnerMode::File(fd) | TestRunnerMode::Fifo(fd) => {
                 close_psp_file(fd);
                 quit_game();
             }

--- a/psp/src/test_runner.rs
+++ b/psp/src/test_runner.rs
@@ -188,7 +188,9 @@ impl<'a> TestRunner<'a> {
                 close_psp_file(fd);
                 quit_game();
             }
-            TestRunnerMode::Dprintln => loop {},
+            TestRunnerMode::Dprintln => loop {
+                core::hint::spin_loop()
+            },
         }
     }
 }

--- a/psp/src/test_runner.rs
+++ b/psp/src/test_runner.rs
@@ -109,8 +109,7 @@ impl<'a> TestRunner<'a> {
                 );
             }
 
-            let mut i = 0;
-            for (li, ri) in l.iter().zip(r.iter()) {
+            for (i, (li, ri)) in l.iter().zip(r.iter()).enumerate() {
                 if li != ri {
                     self.dbg(
                         testcase_name,
@@ -118,7 +117,6 @@ impl<'a> TestRunner<'a> {
                     );
                     break;
                 }
-                i += 1;
             }
 
             self.fail(testcase_name, "Collections were not equal!");

--- a/psp/src/test_runner.rs
+++ b/psp/src/test_runner.rs
@@ -209,7 +209,7 @@ fn get_test_output_pipe() -> SceUid {
                 fd.0
             );
         }
-        return fd;
+        fd
     }
 }
 
@@ -223,7 +223,7 @@ fn get_test_output_file() -> SceUid {
         if fd.0 < 0 {
             panic!("Unable to open file \"{}\" for output!", OUTPUT_FILENAME);
         }
-        return fd;
+        fd
     }
 }
 

--- a/psp/src/vram_alloc.rs
+++ b/psp/src/vram_alloc.rs
@@ -87,7 +87,7 @@ impl SimpleVramAllocator {
     ///
     /// The returned VRAM chunk has the same lifetime as the
     /// `SimpleVramAllocator` borrow (i.e. `&self`) that allocated it.
-    pub fn alloc<'a>(&'a self, size: u32) -> VramMemChunk<'a> {
+    pub fn alloc(&self, size: u32) -> VramMemChunk<'_> {
         let old_offset = self.offset.load(Ordering::Relaxed);
         let new_offset = old_offset + size;
         self.offset.store(new_offset, Ordering::Relaxed);
@@ -100,17 +100,17 @@ impl SimpleVramAllocator {
     }
 
     // TODO: ensure 16-bit alignment?
-    pub fn alloc_sized<'a, T: Sized>(&'a self, count: u32) -> VramMemChunk<'a> {
+    pub fn alloc_sized<T: Sized>(&self, count: u32) -> VramMemChunk<'_> {
         let size = size_of::<T>() as u32;
         self.alloc(count * size)
     }
 
-    pub fn alloc_texture_pixels<'a>(
-        &'a self,
+    pub fn alloc_texture_pixels(
+        &self,
         width: u32,
         height: u32,
         psm: TexturePixelFormat,
-    ) -> VramMemChunk<'a> {
+    ) -> VramMemChunk<'_> {
         let size = get_memory_size(width, height, psm);
         self.alloc(size)
     }

--- a/psp/src/vram_alloc.rs
+++ b/psp/src/vram_alloc.rs
@@ -56,6 +56,10 @@ impl VramMemChunk<'_> {
     pub fn len(&self) -> u32 {
         self.len
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 // A dead-simple VRAM bump allocator.


### PR DESCRIPTION
Fixes many clippy warnings, except for 5 `clippy::missing_safety_doc` in `psp` crate.
Also may fix some UB, bc of merged `ptr::offset` calls.