### PR TITLE
fix: use CARGO environment variable as cargo executable path

### DIFF
--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -198,7 +198,8 @@ fn main() {
         Err(_) => "build-std=core,compiler_builtins,alloc,panic_unwind,panic_abort",
     };
 
-    let mut process = Command::new("cargo")
+    let cargo = env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut process = Command::new(cargo)
         .arg("build")
         .arg("-Z")
         .arg(build_std_flag)


### PR DESCRIPTION
might fix some issues mentioned on discord

https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-3rd-party-subcommands