### PR TITLE
Add no-op eh_personality function to silence CI errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ implementations of graphics functions, and the addition of missing libraries.
 ## Dependencies
 
 To compile for the PSP, you will need a Rust **nightly** version equal to or
-later than `2022-06-11` and the `rust-src` component. Please install Rust using
+later than `2022-09-04` and the `rust-src` component. Please install Rust using
 https://rustup.rs/
 
 Use the following if you are new to Rust. (Feel free to set an override manually

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -120,13 +120,13 @@ impl fmt::Display for CommitDate {
     }
 }
 
-// Minimum 2022-06-11, remember to update both commit date and version too,
+// Minimum 2022-09-03, remember to update both commit date and version too,
 // below. Note that the `day` field lags by one day, as the toolchain always
 // contains the previous days' nightly rustc.
 const MINIMUM_COMMIT_DATE: CommitDate = CommitDate {
     year: 2022,
-    month: 06,
-    day: 10,
+    month: 09,
+    day: 03,
 };
 const MINIMUM_RUSTC_VERSION: Version = Version {
     major: 1,

--- a/ci/concourse/build-rust-macos.yml
+++ b/ci/concourse/build-rust-macos.yml
@@ -1,7 +1,7 @@
 platform: darwin
 
 params:
-  RUSTUP_TOOLCHAIN: nightly-2022-06-11
+  RUSTUP_TOOLCHAIN: nightly-2022-09-04
 
 inputs:
   - name: repo

--- a/ci/concourse/build-rust.yml
+++ b/ci/concourse/build-rust.yml
@@ -11,7 +11,7 @@ image_resource:
     tag: 1.44-slim
 
 params:
-  RUSTUP_TOOLCHAIN: nightly-2022-06-11
+  RUSTUP_TOOLCHAIN: nightly-2022-09-04
 
 inputs:
   - name: repo

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -215,6 +215,13 @@ pub fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     }
 }
 
+// TODO: EH personality was moved from the panic_unwind crate to std in
+// https://github.com/rust-lang/rust/pull/92845. This no-op implementation
+// should be replaced with the version from std when using no_std.
+#[cfg(not(feature = "std"))]
+#[lang = "eh_personality"]
+unsafe extern "C" fn rust_eh_personality() {}
+
 /// These symbols and functions should not actually be used. `libunwind`,
 /// however, requires them to be present so that it can link.
 // TODO: Patch these out of libunwind instead.


### PR DESCRIPTION
This adds a no-op implementation for the `eh_personality` function to silence the daily CI error messages on discord. I believe catching panics is still kinda iffy when using lld, so this shouldn't break anything in the default case.

Also I tried porting over the version from rust to the psp crate, but it's not completely trivial since it depends on the unwind crate in rust (this is different from the one on crates.io). There was also [talk of moving it to a new crate](https://github.com/rust-lang/rust/pull/92845#issuecomment-1018728236) in the [rust PR](https://github.com/rust-lang/rust/pull/92845) that broke CI, so that might be a better option.