### PR TITLE
fix: `SceUtilityOskState` status

### DIFF
--- a/psp/src/sys/utility.rs
+++ b/psp/src/sys/utility.rs
@@ -90,7 +90,6 @@ pub enum SceUtilityOskInputType {
 #[repr(u32)]
 pub enum SceUtilityOskState {
     None,
-    Initializing,
     Initialized,
     Visible,
     Quit,


### PR DESCRIPTION
Fix the enum of OSK (On-Screen Keyboard) status.

The enum had a variant too much (`SceUtilityOskState::Initializing`) that I removed.