### PR TITLE
chore(deps): update num_enum & switch to embedded-graphics-core

### DIFF
--- a/cargo-psp/Cargo.toml
+++ b/cargo-psp/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "cargo-psp"
-version = "0.2.4"
+version = "0.2.5"
 description = "`cargo build` wrapper for creating Sony PSP executables"
 repository = "https://github.com/overdrivenpotato/rust-psp"
 license = "MIT"
 authors = [
     "Marko Mijalkovic <marko.mijalkovic97@gmail.com>",
-    "Paul Sajna <sajattack@gmail.com>"
+    "Paul Sajna <sajattack@gmail.com>",
+    "Josh Wood <sk83rjosh@gmail.com>"
 ]
 edition = "2018"
 default-run = "cargo-psp"

--- a/cargo-psp/src/bin/prxgen.rs
+++ b/cargo-psp/src/bin/prxgen.rs
@@ -211,7 +211,7 @@ impl<'a> PrxBuilder<'a> {
             let program_header = &mut self.program_headers[0];
             program_header.p_type = 1;
             program_header.p_vaddr = 0;
-            program_header.p_paddr = program_header.p_offset + {
+            program_header.p_paddr = {
                 // Check if we are a kernel module.
                 if module_info.sh_flags & 0x100 != 0 {
                     0x80000000 | module_info.sh_offset

--- a/ci/tests/Cargo.toml
+++ b/ci/tests/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 psp = { path = "../../psp", features = ["embedded-graphics"] }
-embedded-graphics = { version = "0.7.1", features = ["fixed_point"]}
+embedded-graphics = { version = "0.8.1", features = ["fixed_point"]}

--- a/examples/embedded-graphics/Cargo.toml
+++ b/examples/embedded-graphics/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 psp = { path = "../../psp", features = ["embedded-graphics"] }
-embedded-graphics = { version = "0.7.1", features = ["fixed_point"]}
+embedded-graphics = { version = "0.8.1", features = ["fixed_point"]}
 tinybmp = { version = "0.3.1" }

--- a/examples/paint-mode/Cargo.toml
+++ b/examples/paint-mode/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 psp = { path = "../../psp", features = ["embedded-graphics"] }
-embedded-graphics = { version = "0.7.1", features = ["fixed_point"]}
+embedded-graphics = { version = "0.8.1", features = ["fixed_point"]}
 numtoa = "0.2"

--- a/psp/Cargo.toml
+++ b/psp/Cargo.toml
@@ -30,9 +30,9 @@ embedded-graphics = { version = "0.7.1", optional = true, features = ["fixed_poi
 unstringify = "0.1.4"
 
 [dependencies.num_enum]
-version = "0.5.0"
+version = "0.7.2"
 default-features = false
 
 [dependencies.num_enum_derive]
-version = "0.5.0"
+version = "0.7.2"
 default-features = false

--- a/psp/Cargo.toml
+++ b/psp/Cargo.toml
@@ -26,7 +26,7 @@ stub-only = []
 paste = "1.0.1"
 bitflags = "1.2.1"
 libm = "0.2.1"
-embedded-graphics = { version = "0.7.1", optional = true, features = ["fixed_point"] }
+embedded-graphics = { version = "0.8.1", optional = true, features = ["fixed_point"] }
 unstringify = "0.1.4"
 
 [dependencies.num_enum]


### PR DESCRIPTION
Bumps dependencies versions:
- num_enum to `0.7.2`
- embedded-graphics: to `0.8.1`.