### PR TITLE
resolve nightly rust build warning

### DIFF
--- a/psp/src/sys/macros.rs
+++ b/psp/src/sys/macros.rs
@@ -186,7 +186,7 @@ macro_rules! psp_extern {
                     $(#[$attr])*
                     #[allow(non_snake_case, clippy::missing_safety_doc)]
                     #[no_mangle]
-                    pub unsafe extern fn $name($($arg : $arg_ty),*) $(-> $ret)? {
+                    pub unsafe extern "C" fn $name($($arg : $arg_ty),*) $(-> $ret)? {
                         #[cfg(target_os = "psp")]
                         {
                             psp_extern!(


### PR DESCRIPTION
Update: this doesn't actually resolve the error, which is a compiler ICE, but it does fix a warning