### PR TITLE
fix: update catch_unwind intrinsic call for bool return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ implementations of graphics functions, and the addition of missing libraries.
 ## Dependencies
 
 To compile for the PSP, you will need a Rust **nightly** version equal to or
-later than `2025-03-19` and the `rust-src` component. Please install Rust using
+later than `2026-05-30` and the `rust-src` component. Please install Rust using
 https://rustup.rs/
 
 Use the following if you are new to Rust. (Feel free to set an override manually

--- a/cargo-psp/src/main.rs
+++ b/cargo-psp/src/main.rs
@@ -140,13 +140,13 @@ impl core::ops::Add<CommitDate> for CommitDate {
 // below. Note that the `day` field lags by one day, as the toolchain always
 // contains the previous days' nightly rustc.
 const MINIMUM_COMMIT_DATE: CommitDate = CommitDate {
-    year: 2025,
-    month: 3,
-    day: 18,
+    year: 2026,
+    month: 05,
+    day: 29,
 };
 const MINIMUM_RUSTC_VERSION: Version = Version {
     major: 1,
-    minor: 87,
+    minor: 96,
     patch: 0,
     pre: Prerelease::EMPTY,
     build: BuildMetadata::EMPTY,

--- a/ci/concourse/build-rust-macos.yml
+++ b/ci/concourse/build-rust-macos.yml
@@ -1,7 +1,7 @@
 platform: darwin
 
 params:
-  RUSTUP_TOOLCHAIN: nightly-2025-03-19
+  RUSTUP_TOOLCHAIN: nightly-2026-05-30
 
 inputs:
   - name: repo

--- a/ci/concourse/build-rust.yml
+++ b/ci/concourse/build-rust.yml
@@ -11,7 +11,7 @@ image_resource:
     tag: 1.44-slim
 
 params:
-  RUSTUP_TOOLCHAIN: nightly-2025-03-19
+  RUSTUP_TOOLCHAIN: nightly-2026-05-30
 
 inputs:
   - name: repo

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -232,7 +232,7 @@ unsafe extern "C" fn rust_eh_personality() {}
 #[cfg(all(target_os = "psp", not(feature = "stub-only")))]
 mod libunwind_shims {
     #[no_mangle]
-    unsafe extern "C" fn fprintf(_stream: *const u8, _format: *const u8, _:...) -> isize {
+    unsafe extern "C" fn fprintf(_stream: *const u8, _format: *const u8, _: ...) -> isize {
         -1
     }
 

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -232,7 +232,7 @@ unsafe extern "C" fn rust_eh_personality() {}
 #[cfg(all(target_os = "psp", not(feature = "stub-only")))]
 mod libunwind_shims {
     #[no_mangle]
-    unsafe extern "C" fn fprintf(_stream: *const u8, _format: *const u8, ...) -> isize {
+    unsafe extern "C" fn fprintf(_stream: *const u8, _format: *const u8, _:...) -> isize {
         -1
     }
 

--- a/psp/src/panic.rs
+++ b/psp/src/panic.rs
@@ -184,7 +184,7 @@ pub fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     let data_ptr = &mut data as *mut _ as *mut u8;
 
     return unsafe {
-        if core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
+        if !core::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) {
             Ok(ManuallyDrop::into_inner(data.r))
         } else {
             Err(ManuallyDrop::into_inner(data.p))


### PR DESCRIPTION
Fixes the compilation failure introduced by rust-lang/rust#156867

Closes #197